### PR TITLE
fix: 🔧 Update Perplexity button selector for new DOM structure

### DIFF
--- a/src/content/core/injector.ts
+++ b/src/content/core/injector.ts
@@ -727,8 +727,8 @@ export class PromptLibraryInjector {
         
         // For Perplexity, find the toolbar container and inject as first child
         if (this.state.hostname === 'www.perplexity.ai' && !injected) {
-          // Look for the toolbar container with class pattern matching
-          const toolbarContainer = document.querySelector('div.bg-raised[class*="flex"][class*="items-center"][class*="rounded-full"]');
+          // Use the strategy's button container selector
+          const toolbarContainer = document.querySelector(containerSelector);
           if (toolbarContainer) {
             // Insert as the first child in the container
             toolbarContainer.insertBefore(icon, toolbarContainer.firstChild);

--- a/src/content/platforms/perplexity-strategy.ts
+++ b/src/content/platforms/perplexity-strategy.ts
@@ -16,7 +16,7 @@ export class PerplexityStrategy extends PlatformStrategy {
       selectors: [
         'div[contenteditable="true"][role="textbox"]#ask-input'
       ],
-      buttonContainerSelector: '.bg-raised.flex.items-center.justify-self-end.rounded-full',
+      buttonContainerSelector: '.flex.items-center.justify-self-end.col-start-3.row-start-2',
       priority: 80
     });
   }


### PR DESCRIPTION
## Problem

The "My Prompts" icon was not appearing on Perplexity.ai due to a DOM structure change on their platform.

**Root Cause:**
- Perplexity updated their UI, changing the CSS classes of the button toolbar container  
- Old selector: `.bg-raised.flex.items-center.justify-self-end.rounded-full`
- New DOM structure: `<div class="flex items-center justify-self-end col-start-3 row-start-2">`

## Solution

Updated the Perplexity platform strategy to use the correct selector and improved code maintainability:

### Technical Changes

1. **Updated PerplexityStrategy** - Changed `buttonContainerSelector` to target CSS Grid layout structure
2. **Improved Injector Logic** - Replaced hardcoded selector with dynamic strategy selector

## Impact

✅ Restores functionality on Perplexity.ai  
✅ Improves code maintainability  
✅ No regressions - all 470 tests pass  

🤖 Generated with [Claude Code](https://claude.ai/code)