### PR TITLE
feat: Change default interface mode from popup to sidepanel

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -808,7 +808,7 @@ async function handleExtensionUpdate(): Promise<void> {
  */
 async function getInterfaceMode(): Promise<InterfaceMode> {
   const result = await chrome.storage.local.get('interfaceMode');
-  return (result.interfaceMode as InterfaceMode | undefined) || 'popup';
+  return (result.interfaceMode as InterfaceMode | undefined) || 'sidepanel';
 }
 
 

--- a/src/types/__tests__/index.test.ts
+++ b/src/types/__tests__/index.test.ts
@@ -18,7 +18,7 @@ describe('Type Definitions', () => {
         defaultCategory: 'Uncategorized',
         sortOrder: 'updatedAt',
         theme: 'system',
-        interfaceMode: 'popup'
+        interfaceMode: 'sidepanel'
       });
     });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,5 +97,5 @@ export const DEFAULT_SETTINGS: Settings = {
   defaultCategory: DEFAULT_CATEGORY,
   sortOrder: 'updatedAt',
   theme: 'system',
-  interfaceMode: 'popup'
+  interfaceMode: 'sidepanel'
 };


### PR DESCRIPTION
Update the default interface mode preference to use the sidepanel instead of popup window, providing users with a better workflow experience by default.

Changes:
- Update DEFAULT_SETTINGS.interfaceMode to 'sidepanel' in types/index.ts
- Update getInterfaceMode() fallback to 'sidepanel' in background.ts
- Update corresponding unit test expectations

The sidepanel interface offers better multitasking capabilities and stays accessible while browsing, making it more suitable as the default experience for new users.

🤖 Generated with [Claude Code](https://claude.ai/code)