### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Prompt Manager - Chrome Extension
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](https://github.com/spartDev/My-Prompt-Manager)
+[![Version](https://img.shields.io/badge/version-1.2.1-blue.svg)](https://github.com/spartDev/My-Prompt-Manager)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Chrome](https://img.shields.io/badge/Chrome-114%2B-yellow.svg)](https://www.google.com/chrome/)
 [![Tests](https://img.shields.io/badge/tests-470%20passing-brightgreen.svg)](https://github.com/spartDev/My-Prompt-Manager)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "My Prompt Manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Store, organize, and quickly access your personal collection of text prompts with categories and search functionality.",
   "author": "Thomas Roux",
   "homepage_url": "https://github.com/spartDev/My-Prompt-Manager",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prompt-library-extension",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prompt-library-extension",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@types/dompurify": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-library-extension",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Chrome extension for managing personal prompt library",
   "license": "MIT",
   "type": "module",

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -451,7 +451,7 @@ const SettingsView: FC<SettingsViewProps> = ({ onBack }) => {
 
           {/* About & Reset Section */}
           <AboutSection
-            version="1.2.0"
+            version="1.2.1"
             onReset={handleResetSettings}
           />
         </div>


### PR DESCRIPTION
Version bump to 1.2.1 reflecting recent patch fixes and dependency updates.

  ## Changes Included in This Release

  Since v1.2.0, the following commits have been merged:
  - **fix**: Element picker content script injection in Chrome Web Store published extensions (#28)
  - **fix**: Interface mode setting display correction (#27)
  - **chore(deps)**: Pin dependencies (#26)

  ## Version Updates

  Updated version across all relevant files:
  - \`package.json\` → 1.2.1
  - \`manifest.json\` → 1.2.1
  - \`README.md\` version badge → 1.2.1
  - \`src/components/SettingsView.tsx\` → 1.2.1
  - \`package-lock.json\` → 1.2.1 (package version only, no dependency changes)

  ## Semantic Versioning
  **Type**: Patch release (1.2.0 → 1.2.1)                                                                                                                                                                                     - 2 bug fixes
  - 1 dependency maintenance task                                                                                                                                                                                             - No breaking changes
  - No new features
  ## Testing

  - ✅ All 470 tests pass
  - ✅ Build completes successfully
  - ✅ Production manifest correctly shows v1.2.1
  - ✅ No dependency versions inappropriately modified

  ## Release Notes

  This patch release resolves a critical issue with the element picker functionality when the extension is published to the Chrome Web Store, along with a UI display correction.

🤖 Generated with [Claude Code](https://claude.ai/code)