### PR TITLE
feat: share custom website configurations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/dompurify": "3.2.0",
         "dompurify": "3.2.7",
+        "lz-string": "^1.5.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "uuid": "10.0.0"
@@ -6339,9 +6340,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@types/dompurify": "3.2.0",
     "dompurify": "3.2.7",
+    "lz-string": "^1.5.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "uuid": "10.0.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,6 +222,7 @@ const App: FC<AppProps> = ({ context = 'popup' }) => {
             void refreshPrompts();
             void refreshCategories();
           }}
+          showToast={showToast}
         />
       )}
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -443,13 +443,13 @@ class ContentScriptInjector {
         } catch {
           // File doesn't exist, continue to fallbacks
           if (this.isDebugMode()) {
-            console.warn('[ContentScriptInjector] Manifest content script path not accessible:', contentScriptPath);
+            console.error('[ContentScriptInjector] Manifest content script path not accessible:', contentScriptPath);
           }
         }
       }
     } catch (error) {
       if (this.isDebugMode()) {
-        console.warn('[ContentScriptInjector] Failed to read manifest:', error);
+        console.error('[ContentScriptInjector] Failed to read manifest:', error);
       }
     }
 
@@ -467,7 +467,7 @@ class ContentScriptInjector {
           return contentEntry.file;
         } catch {
           if (this.isDebugMode()) {
-            console.warn('[ContentScriptInjector] Build manifest content script not accessible:', contentEntry.file);
+            console.error('[ContentScriptInjector] Build manifest content script not accessible:', contentEntry.file);
           }
         }
       }
@@ -485,14 +485,14 @@ class ContentScriptInjector {
           return contentFiles[0];
         } catch {
           if (this.isDebugMode()) {
-            console.warn('[ContentScriptInjector] Build manifest content file not accessible:', contentFiles[0]);
+            console.error('[ContentScriptInjector] Build manifest content file not accessible:', contentFiles[0]);
           }
         }
       }
     } catch {
       // .vite/manifest.json doesn't exist (expected in Chrome Web Store builds)
       if (this.isDebugMode()) {
-        console.info('[ContentScriptInjector] Build manifest not available, trying direct file discovery');
+        console.error('[ContentScriptInjector] Build manifest not available, trying direct file discovery');
       }
     }
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -43,6 +43,7 @@ interface Settings {
 
 interface SettingsViewProps {
   onBack: () => void;
+  showToast: (message: string, type?: 'success' | 'error' | 'info') => void;
 }
 
 const SectionSeparator: FC = () => (
@@ -59,7 +60,7 @@ const SectionSeparator: FC = () => (
   </div>
 );
 
-const SettingsView: FC<SettingsViewProps> = ({ onBack }) => {
+const SettingsView: FC<SettingsViewProps> = ({ onBack, showToast }) => {
   const [settings, setSettings] = useState<Settings>({
     enabledSites: [],
     customSites: [],
@@ -428,6 +429,7 @@ const SettingsView: FC<SettingsViewProps> = ({ onBack }) => {
             onRemoveCustomSite={(hostname) => void handleRemoveCustomSite(hostname)}
             onAddCustomSite={(siteData) => void handleAddCustomSite(siteData)}
             saving={saving}
+            onShowToast={showToast}
           />
 
           <SectionSeparator />

--- a/src/components/settings/AddCustomSiteCard.tsx
+++ b/src/components/settings/AddCustomSiteCard.tsx
@@ -1,0 +1,66 @@
+import { FC, useId } from 'react';
+
+interface AddCustomSiteCardProps {
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+  tooltip?: string;
+}
+
+const AddCustomSiteCard: FC<AddCustomSiteCardProps> = ({
+  onClick,
+  disabled = false,
+  className = '',
+  tooltip
+}) => {
+  const descriptionId = useId();
+
+  const baseClasses = `
+    group relative flex h-full flex-col gap-3 rounded-xl border border-gray-200 dark:border-gray-700
+    bg-white dark:bg-gray-800 p-4 text-left transition-all duration-200
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/70
+  `;
+
+  const stateClasses = disabled
+    ? 'cursor-not-allowed opacity-80 bg-gray-100 dark:bg-gray-800/70 border-gray-300 dark:border-gray-600'
+    : 'cursor-pointer hover:border-purple-300 dark:hover:border-purple-600 hover:shadow-sm';
+
+  const iconClasses = disabled
+    ? 'bg-purple-100 text-purple-400 dark:bg-purple-900/30 dark:text-purple-500'
+    : 'bg-purple-100 text-purple-600 group-hover:bg-purple-200 group-hover:text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 dark:group-hover:bg-purple-800/70 dark:group-hover:text-purple-200';
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (!disabled) {
+          onClick();
+        }
+      }}
+      disabled={disabled}
+      aria-disabled={disabled}
+      aria-label="Add new custom site integration"
+      aria-describedby={descriptionId}
+      className={`${baseClasses} ${stateClasses} ${className}`}
+      title={tooltip}
+    >
+      <div className="flex items-start gap-3">
+        <span className={`flex h-10 w-10 items-center justify-center rounded-lg transition-colors duration-200 ${iconClasses}`}>
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+          </svg>
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Add Custom Site
+          </p>
+          <p id={descriptionId} className="text-xs text-gray-600 dark:text-gray-400">
+            Configure a new AI platform integration
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default AddCustomSiteCard;

--- a/src/components/settings/ConfigurationPreview.tsx
+++ b/src/components/settings/ConfigurationPreview.tsx
@@ -1,0 +1,181 @@
+import { useEffect } from 'react';
+import type { FC } from 'react';
+import { createPortal } from 'react-dom';
+
+import type { CustomSiteConfiguration, SecurityWarning } from '../../types';
+
+interface ConfigurationPreviewProps {
+  isOpen: boolean;
+  config: CustomSiteConfiguration | null;
+  warnings: SecurityWarning[];
+  duplicate: boolean;
+  existingDisplayName?: string;
+  onClose: () => void;
+  onConfirm: () => void;
+  isProcessing?: boolean;
+}
+
+const ConfigurationPreview: FC<ConfigurationPreviewProps> = ({
+  isOpen,
+  config,
+  warnings,
+  duplicate,
+  existingDisplayName,
+  onClose,
+  onConfirm,
+  isProcessing = false
+}) => {
+  useEffect(() => {
+    if (!isOpen) {return;}
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => { document.removeEventListener('keydown', handleKeyDown); };
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !config) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black bg-opacity-40" aria-hidden="true" onClick={onClose}></div>
+      <div className="relative max-w-md w-full bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 p-5 space-y-4">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              Review Configuration
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Confirm the details before importing this custom site.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            aria-label="Close preview"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+            <p className="text-xs uppercase font-semibold text-gray-500 dark:text-gray-400">Hostname</p>
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100 break-all">{config.hostname}</p>
+          </div>
+          <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+            <p className="text-xs uppercase font-semibold text-gray-500 dark:text-gray-400">Display Name</p>
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{config.displayName}</p>
+          </div>
+
+          {config.positioning && (
+            <div className="rounded-lg border border-indigo-200 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 p-3 space-y-2">
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p className="text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase">Custom Placement</p>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+                <div>
+                  <p className="text-xs text-indigo-600 dark:text-indigo-300 uppercase">Selector</p>
+                  <p className="text-sm font-medium text-indigo-900 dark:text-indigo-100 break-all">{config.positioning.selector}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-indigo-600 dark:text-indigo-300 uppercase">Placement</p>
+                  <p className="text-sm font-medium text-indigo-900 dark:text-indigo-100">{config.positioning.placement}</p>
+                </div>
+                {config.positioning.offset && (
+                  <div>
+                    <p className="text-xs text-indigo-600 dark:text-indigo-300 uppercase">Offset</p>
+                    <p className="text-sm font-medium text-indigo-900 dark:text-indigo-100">
+                      x: {config.positioning.offset.x}, y: {config.positioning.offset.y}
+                    </p>
+                  </div>
+                )}
+                {config.positioning.zIndex !== undefined && (
+                  <div>
+                    <p className="text-xs text-indigo-600 dark:text-indigo-300 uppercase">Z-Index</p>
+                    <p className="text-sm font-medium text-indigo-900 dark:text-indigo-100">{config.positioning.zIndex}</p>
+                  </div>
+                )}
+                {config.positioning.description && (
+                  <div className="sm:col-span-2">
+                    <p className="text-xs text-indigo-600 dark:text-indigo-300 uppercase">Description</p>
+                    <p className="text-sm font-medium text-indigo-900 dark:text-indigo-100">{config.positioning.description}</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div className="rounded-lg border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-3">
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-amber-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p className="text-xs font-semibold text-amber-700 dark:text-amber-300 uppercase">Security Notes</p>
+              </div>
+              <ul className="mt-2 space-y-1">
+                {warnings.map((warning) => (
+                  <li key={`${warning.field}-${warning.message}`} className="text-xs text-amber-700 dark:text-amber-200">
+                    <strong>{warning.field}</strong>: {warning.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {duplicate && (
+            <div className="rounded-lg border border-red-200 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-3">
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-red-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p className="text-xs font-semibold text-red-700 dark:text-red-300 uppercase">Existing Configuration</p>
+              </div>
+              <p className="mt-1 text-xs text-red-700 dark:text-red-200">
+                A custom site named <strong>{existingDisplayName ?? config.displayName}</strong> already exists for this hostname. Importing will replace the current setup.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="pt-3 border-t border-gray-200 dark:border-gray-700 flex justify-between gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isProcessing}
+            className={`px-4 py-2 text-sm font-semibold rounded-lg transition-colors ${
+              isProcessing
+                ? 'bg-green-300 dark:bg-green-800 text-green-900 dark:text-green-200 cursor-wait'
+                : 'bg-green-600 hover:bg-green-700 text-white'
+            }`}
+          >
+            {isProcessing ? 'Importing...' : duplicate ? 'Overwrite & Import' : 'Import Configuration'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ConfigurationPreview;

--- a/src/components/settings/ExportButton.tsx
+++ b/src/components/settings/ExportButton.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react';
+
+interface ExportButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+const ExportButton: FC<ExportButtonProps> = ({ onClick, disabled = false, loading = false }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${
+      disabled
+        ? 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+        : 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/40'
+    }`}
+    aria-label={loading ? 'Exporting configuration' : 'Export custom site configuration'}
+  >
+    {loading ? (
+      <svg className="w-3 h-3 animate-spin" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364-6.364l-2.121 2.121M8.757 15.243l-2.121 2.121m0-12.728l2.121 2.121m8.486 8.486l2.121 2.121" />
+      </svg>
+    ) : (
+      <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M16 12l-4-4m0 0l-4 4m4-4v12" />
+      </svg>
+    )}
+    {loading ? 'Copying...' : 'Export'}
+  </button>
+);
+
+export default ExportButton;

--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -26,9 +26,6 @@ const ImportSection: FC<ImportSectionProps> = ({
       <div className="flex items-center justify-between">
         <div>
           <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">Import Configuration</h4>
-          <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
-            Paste a configuration code shared by another user to preview before importing.
-          </p>
         </div>
         {value && (
           <button

--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -1,0 +1,79 @@
+import type { ChangeEvent, FC } from 'react';
+
+interface ImportSectionProps {
+  value: string;
+  onChange: (value: string) => void;
+  onPreview: () => void;
+  onClear: () => void;
+  loading?: boolean;
+  error?: string | null;
+}
+
+const ImportSection: FC<ImportSectionProps> = ({
+  value,
+  onChange,
+  onPreview,
+  onClear,
+  loading = false,
+  error = null
+}) => {
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <div className="mb-4 p-4 bg-slate-50 dark:bg-slate-900/40 border border-slate-200 dark:border-slate-700 rounded-xl">
+      <div className="flex items-center justify-between">
+        <div>
+          <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">Import Configuration</h4>
+          <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
+            Paste a configuration code shared by another user to preview before importing.
+          </p>
+        </div>
+        {value && (
+          <button
+            type="button"
+            onClick={onClear}
+            disabled={loading}
+            className="text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:text-gray-400"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <textarea
+        value={value}
+        onChange={handleChange}
+        placeholder="Enter configuration code here"
+        rows={3}
+        className="mt-3 w-full resize-y min-h-[96px] px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+        aria-label="Encoded configuration string"
+      />
+
+      {error && (
+        <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      <div className="mt-3 space-y-2">
+        <button
+          type="button"
+          onClick={onPreview}
+          disabled={loading || !value.trim()}
+          className={`w-full px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+            loading || !value.trim()
+              ? 'bg-purple-200 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 cursor-not-allowed'
+              : 'bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:from-purple-700 hover:to-indigo-700'
+          }`}
+        >
+          {loading ? 'Validating...' : 'Preview Configuration'}
+        </button>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          We will validate and sanitize configs before they are saved.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ImportSection;

--- a/src/components/settings/SiteCard.tsx
+++ b/src/components/settings/SiteCard.tsx
@@ -1,5 +1,7 @@
 import { FC, ReactNode } from 'react';
 
+import ExportButton from './ExportButton';
+
 // Function to get brand-specific background colors
 const getBrandColors = (hostname: string) => {
   switch (hostname) {
@@ -34,9 +36,11 @@ interface SiteCardProps {
   icon: ReactNode;
   isEnabled: boolean;
   isCustom?: boolean;
-  onToggle: (hostname: string, enabled: boolean) => void;
-  onRemove?: (hostname: string) => void;
-  onEdit?: (hostname: string) => void;
+  onToggle: (hostname: string, enabled: boolean) => Promise<void> | void;
+  onRemove?: (hostname: string) => Promise<void> | void;
+  onEdit?: (hostname: string) => Promise<void> | void;
+  onExport?: (hostname: string) => Promise<void> | void;
+  exporting?: boolean;
   saving?: boolean;
 }
 
@@ -50,6 +54,8 @@ const SiteCard: FC<SiteCardProps> = ({
   onToggle,
   onRemove,
   onEdit,
+  onExport,
+  exporting = false,
   saving = false
 }) => {
   const brandColors = getBrandColors(hostname);
@@ -100,7 +106,7 @@ const SiteCard: FC<SiteCardProps> = ({
           <input
             type="checkbox"
             checked={isEnabled}
-            onChange={(e) => { onToggle(hostname, e.target.checked); }}
+            onChange={(e) => { void onToggle(hostname, e.target.checked); }}
             disabled={saving}
             className="sr-only peer"
             aria-label={`Enable ${name} integration`}
@@ -111,10 +117,17 @@ const SiteCard: FC<SiteCardProps> = ({
 
       {/* Custom Site Actions */}
       {isCustom && (
-        <div className="flex gap-1 mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+        <div className="flex gap-1 flex-wrap mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+          {onExport && (
+            <ExportButton
+              onClick={() => { void onExport(hostname); }}
+              disabled={saving}
+              loading={exporting}
+            />
+          )}
           {onEdit && (
             <button
-              onClick={() => { onEdit(hostname); }}
+              onClick={() => { void onEdit(hostname); }}
               disabled={saving}
               className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs font-medium text-purple-600 dark:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded transition-colors"
             >
@@ -126,7 +139,7 @@ const SiteCard: FC<SiteCardProps> = ({
           )}
           {onRemove && (
             <button
-              onClick={() => { onRemove(hostname); }}
+              onClick={() => { void onRemove(hostname); }}
               disabled={saving}
               className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
             >

--- a/src/components/settings/SiteIntegrationSection.tsx
+++ b/src/components/settings/SiteIntegrationSection.tsx
@@ -667,18 +667,18 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
           </div>
 
           {showAddMethodChooser && (
-            <div className="mb-4 rounded-xl border border-purple-200 dark:border-purple-700 bg-white dark:bg-gray-900 shadow-sm">
+            <div className="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm">
               <div className="flex items-start justify-between gap-3 p-4 pb-3">
                 <div>
-                  <h4 className="text-sm font-semibold text-purple-800 dark:text-purple-200">How would you like to add this site?</h4>
-                  <p className="text-xs text-purple-700/80 dark:text-purple-200/70 mt-1">
+                  <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">How would you like to add this site?</h4>
+                  <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
                     Choose a method to continue. You can always switch later.
                   </p>
                 </div>
                 <button
                   type="button"
                   onClick={() => { setShowAddMethodChooser(false); }}
-                  className="text-purple-700 dark:text-purple-200 hover:text-purple-900 dark:hover:text-purple-100"
+                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
                   aria-label="Dismiss add site options"
                 >
                   <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
@@ -690,10 +690,10 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
                 <button
                   type="button"
                   onClick={openManualFlow}
-                  className="group flex h-full flex-col justify-between gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-left transition-all hover:border-purple-400 hover:shadow dark:border-gray-700 dark:bg-gray-900 dark:hover:border-purple-500"
+                  className="group flex h-full flex-col justify-between gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-left transition-all hover:border-purple-300 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:hover:border-purple-500/70"
                 >
                   <div className="flex items-start gap-3">
-                    <span className="flex h-9 w-9 items-center justify-center rounded-md bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-md bg-purple-50 text-purple-600 dark:bg-purple-900/30 dark:text-purple-200">
                       <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-3-3v6m9-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
@@ -709,10 +709,10 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
                 <button
                   type="button"
                   onClick={openImportFlow}
-                  className="group flex h-full flex-col justify-between gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-left transition-all hover:border-purple-400 hover:shadow dark:border-gray-700 dark:bg-gray-900 dark:hover:border-purple-500"
+                  className="group flex h-full flex-col justify-between gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-left transition-all hover:border-purple-300 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:hover:border-purple-500/70"
                 >
                   <div className="flex items-start gap-3">
-                    <span className="flex h-9 w-9 items-center justify-center rounded-md bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-md bg-purple-50 text-purple-600 dark:bg-purple-900/30 dark:text-purple-200">
                       <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8m-2 8H5a2 2 0 01-2-2V8m18 0v6a2 2 0 01-2 2" />
                       </svg>

--- a/src/components/settings/SiteIntegrationSection.tsx
+++ b/src/components/settings/SiteIntegrationSection.tsx
@@ -624,7 +624,6 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
   const addFirstSiteTooltip = addActionDisabled
     ? `Current site (${currentSiteHostname}) is already integrated`
     : 'Add your first custom site';
-  const addActionStatusLabel = addActionDisabled ? 'Site Already Added' : 'New Custom Site';
   const addFirstSiteLabel = addActionDisabled ? 'Current Site Already Added' : 'Add Your First Site';
 
   return (
@@ -665,26 +664,6 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
             <h3 className="font-medium text-gray-900 dark:text-gray-100 text-sm">
               Custom Sites
             </h3>
-            {customSites.length === 0 && (
-              <div className="flex items-center gap-2 flex-wrap">
-                <button
-                  type="button"
-                  onClick={openAddMethodSelector}
-                  disabled={addActionDisabled}
-                  className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
-                    addActionDisabled
-                      ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
-                      : 'bg-purple-600 text-white hover:bg-purple-700'
-                  }`}
-                  title={addCardTooltip}
-                >
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                  </svg>
-                  {addActionStatusLabel}
-                </button>
-              </div>
-            )}
           </div>
 
           {showAddMethodChooser && (

--- a/src/components/settings/SiteIntegrationSection.tsx
+++ b/src/components/settings/SiteIntegrationSection.tsx
@@ -5,6 +5,7 @@ import { ConfigurationEncoder, ConfigurationEncoderError } from '../../services/
 import { CustomSite, CustomSiteConfiguration, SecurityWarning } from '../../types';
 import { CustomSiteIcon } from '../icons/SiteIcons';
 
+import AddCustomSiteCard from './AddCustomSiteCard';
 import ConfigurationPreview from './ConfigurationPreview';
 import ImportSection from './ImportSection';
 import SettingsSection from './SettingsSection';
@@ -88,6 +89,13 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
     setPickingElement(false);
     setPickerError(null);
   }, []);
+
+  const openAddMethodSelector = useCallback(() => {
+    resetAddSiteForm();
+    setShowImportDrawer(false);
+    setShowAddSite(false);
+    setShowAddMethodChooser(true);
+  }, [resetAddSiteForm]);
 
   const openManualFlow = useCallback(() => {
     resetAddSiteForm();
@@ -597,6 +605,28 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
     setShowAddMethodChooser(false);
   };
 
+  const currentSiteHostname = (() => {
+    if (!currentTabUrl) {
+      return 'this website';
+    }
+
+    try {
+      return new URL(currentTabUrl).hostname;
+    } catch {
+      return 'this website';
+    }
+  })();
+
+  const addActionDisabled = !isPickerWindow && isCurrentSiteIntegrated;
+  const addCardTooltip = addActionDisabled
+    ? `Current site (${currentSiteHostname}) is already integrated`
+    : 'Add a new custom site';
+  const addFirstSiteTooltip = addActionDisabled
+    ? `Current site (${currentSiteHostname}) is already integrated`
+    : 'Add your first custom site';
+  const addActionStatusLabel = addActionDisabled ? 'Site Already Added' : 'New Custom Site';
+  const addFirstSiteLabel = addActionDisabled ? 'Current Site Already Added' : 'Add Your First Site';
+
   return (
     <>
     <SettingsSection
@@ -635,33 +665,26 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
             <h3 className="font-medium text-gray-900 dark:text-gray-100 text-sm">
               Custom Sites
             </h3>
-            <div className="flex items-center gap-2 flex-wrap">
-              <button
-                type="button"
-                onClick={() => {
-                  resetAddSiteForm();
-                  setShowImportDrawer(false);
-                  setShowAddSite(false);
-                  setShowAddMethodChooser(true);
-                }}
-                disabled={!isPickerWindow && isCurrentSiteIntegrated}
-                className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
-                  !isPickerWindow && isCurrentSiteIntegrated
-                    ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
-                    : 'bg-purple-600 text-white hover:bg-purple-700'
-                }`}
-                title={
-                  !isPickerWindow && isCurrentSiteIntegrated 
-                    ? `Current site (${currentTabUrl ? new URL(currentTabUrl).hostname : 'this website'}) is already integrated`
-                    : 'Add a new custom site'
-                }
-              >
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                </svg>
-                {!isPickerWindow && isCurrentSiteIntegrated ? 'Site Already Added' : 'New Custom Site'}
-              </button>
-            </div>
+            {customSites.length === 0 && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <button
+                  type="button"
+                  onClick={openAddMethodSelector}
+                  disabled={addActionDisabled}
+                  className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
+                    addActionDisabled
+                      ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
+                      : 'bg-purple-600 text-white hover:bg-purple-700'
+                  }`}
+                  title={addCardTooltip}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                  </svg>
+                  {addActionStatusLabel}
+                </button>
+              </div>
+            )}
           </div>
 
           {showAddMethodChooser && (
@@ -1024,6 +1047,11 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
                   saving={saving}
                 />
               ))}
+              <AddCustomSiteCard
+                onClick={openAddMethodSelector}
+                disabled={addActionDisabled}
+                tooltip={addCardTooltip}
+              />
             </div>
           ) : (
             !showAddSite && (
@@ -1039,28 +1067,19 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
                     Add any website to use your prompt library there
                   </p>
                 <button
-                  onClick={() => {
-                    resetAddSiteForm();
-                    setShowImportDrawer(false);
-                    setShowAddSite(false);
-                    setShowAddMethodChooser(true);
-                  }}
-                  disabled={!isPickerWindow && isCurrentSiteIntegrated}
+                  onClick={openAddMethodSelector}
+                  disabled={addActionDisabled}
                   className={`inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-                    !isPickerWindow && isCurrentSiteIntegrated
+                    addActionDisabled
                       ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
                       : 'bg-purple-600 text-white hover:bg-purple-700'
                   }`}
-                  title={
-                    !isPickerWindow && isCurrentSiteIntegrated 
-                      ? `Current site (${currentTabUrl ? new URL(currentTabUrl).hostname : 'this website'}) is already integrated`
-                      : 'Add your first custom site'
-                  }
+                  title={addFirstSiteTooltip}
                 >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
                     </svg>
-                    {!isPickerWindow && isCurrentSiteIntegrated ? 'Current Site Already Added' : 'Add Your First Site'}
+                    {addFirstSiteLabel}
                   </button>
                 </div>
               </>

--- a/src/components/settings/SiteIntegrationSection.tsx
+++ b/src/components/settings/SiteIntegrationSection.tsx
@@ -66,6 +66,7 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
   const [confirmingImport, setConfirmingImport] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+  const [showImportSection, setShowImportSection] = useState(false);
 
   const notify = useCallback((message: string, type: 'success' | 'error' | 'info' = 'info') => {
     if (onShowToast) {
@@ -83,6 +84,7 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
         notify('Configuration copied to clipboard', 'success');
       } else {
         setImportCode(encoded);
+        setShowImportSection(true);
         setImportError('Clipboard access was blocked. The configuration code is now in the import field for manual copying.');
         notify('Clipboard access was blocked. The configuration code has been added to the import field.', 'error');
       }
@@ -152,6 +154,7 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
     setPendingImport(null);
     setPreviewOpen(false);
     setImportingConfig(true);
+    setShowImportSection(true);
 
     try {
       const decodedConfig = await ConfigurationEncoder.decode(importCode.trim());
@@ -617,38 +620,45 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
             <h3 className="font-medium text-gray-900 dark:text-gray-100 text-sm">
               Custom Sites
             </h3>
-            <button
-              onClick={() => { setShowAddSite(true); }}
-              disabled={!isPickerWindow && isCurrentSiteIntegrated}
-              className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
-                !isPickerWindow && isCurrentSiteIntegrated
-                  ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
-                  : 'bg-purple-600 text-white hover:bg-purple-700'
-              }`}
-              title={
-                !isPickerWindow && isCurrentSiteIntegrated 
-                  ? `Current site (${currentTabUrl ? new URL(currentTabUrl).hostname : 'this website'}) is already integrated`
-                  : 'Add a new custom site'
-              }
-            >
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-              </svg>
-              {!isPickerWindow && isCurrentSiteIntegrated ? 'Site Already Added' : 'Add Site'}
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => { setShowImportSection(prev => !prev); }}
+                aria-expanded={showImportSection}
+                className={`flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors ${
+                  showImportSection
+                    ? 'border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    : 'border-purple-200 dark:border-purple-700 text-purple-600 dark:text-purple-300 bg-white dark:bg-gray-800 hover:bg-purple-50 dark:hover:bg-purple-900/20'
+                }`}
+                title={showImportSection ? 'Hide import tools' : 'Show import tools'}
+              >
+                <svg className={`w-3.5 h-3.5 ${showImportSection ? 'transform rotate-180' : ''}`} fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+                {showImportSection ? 'Hide Import' : 'Import Configuration'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowAddSite(true); }}
+                disabled={!isPickerWindow && isCurrentSiteIntegrated}
+                className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
+                  !isPickerWindow && isCurrentSiteIntegrated
+                    ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
+                    : 'bg-purple-600 text-white hover:bg-purple-700'
+                }`}
+                title={
+                  !isPickerWindow && isCurrentSiteIntegrated 
+                    ? `Current site (${currentTabUrl ? new URL(currentTabUrl).hostname : 'this website'}) is already integrated`
+                    : 'Add a new custom site'
+                }
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                </svg>
+                {!isPickerWindow && isCurrentSiteIntegrated ? 'Site Already Added' : 'Add Site'}
+              </button>
+            </div>
           </div>
-
-          <ImportSection
-            value={importCode}
-            onChange={(value) => {
-              setImportCode(value);
-              setImportError(null);
-            }}
-            onPreview={() => { void handlePreviewImport(); }}
-            onClear={handleClearImport}
-            loading={importingConfig}
-            error={importError}
-          />
 
           {/* Add Site Form */}
           {showAddSite && (
@@ -911,37 +921,70 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
             </div>
           ) : (
             !showAddSite && (
-              <div className="text-center py-8 px-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600">
-                <svg className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-3" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
-                </svg>
-                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
-                  No custom sites added
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                  Add any website to use your prompt library there
-                </p>
-                <button
-                  onClick={() => { setShowAddSite(true); }}
-                  disabled={!isPickerWindow && isCurrentSiteIntegrated}
-                  className={`inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-                    !isPickerWindow && isCurrentSiteIntegrated
-                      ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
-                      : 'bg-purple-600 text-white hover:bg-purple-700'
-                  }`}
-                  title={
-                    !isPickerWindow && isCurrentSiteIntegrated 
-                      ? `Current site (${currentTabUrl ? new URL(currentTabUrl).hostname : 'this website'}) is already integrated`
-                      : 'Add your first custom site'
-                  }
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+              <>
+                <div className="text-center py-8 px-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600">
+                  <svg className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-3" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
                   </svg>
-                  {!isPickerWindow && isCurrentSiteIntegrated ? 'Current Site Already Added' : 'Add Your First Site'}
-                </button>
-              </div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+                    No custom sites added
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                    Add any website to use your prompt library there
+                  </p>
+                  <button
+                    onClick={() => { setShowAddSite(true); }}
+                    disabled={!isPickerWindow && isCurrentSiteIntegrated}
+                    className={`inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+                      !isPickerWindow && isCurrentSiteIntegrated
+                        ? 'bg-gray-400 dark:bg-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed'
+                        : 'bg-purple-600 text-white hover:bg-purple-700'
+                    }`}
+                    title={
+                      !isPickerWindow && isCurrentSiteIntegrated 
+                        ? `Current site (${currentTabUrl ? new URL(currentTabUrl).hostname : 'this website'}) is already integrated`
+                        : 'Add your first custom site'
+                    }
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                    </svg>
+                    {!isPickerWindow && isCurrentSiteIntegrated ? 'Current Site Already Added' : 'Add Your First Site'}
+                  </button>
+                </div>
+                {showImportSection && (
+                  <div className="mt-4">
+                    <ImportSection
+                      value={importCode}
+                      onChange={(value) => {
+                        setImportCode(value);
+                        setImportError(null);
+                      }}
+                      onPreview={() => { void handlePreviewImport(); }}
+                      onClear={handleClearImport}
+                      loading={importingConfig}
+                      error={importError}
+                    />
+                  </div>
+                )}
+              </>
             )
+          )}
+
+          {customSites.length > 0 && showImportSection && (
+            <div className="mt-4">
+              <ImportSection
+                value={importCode}
+                onChange={(value) => {
+                  setImportCode(value);
+                  setImportError(null);
+                }}
+                onPreview={() => { void handlePreviewImport(); }}
+                onClear={handleClearImport}
+                loading={importingConfig}
+                error={importError}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/settings/SiteIntegrationSection.tsx
+++ b/src/components/settings/SiteIntegrationSection.tsx
@@ -66,7 +66,7 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
   const [confirmingImport, setConfirmingImport] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
-  const [showImportSection, setShowImportSection] = useState(false);
+  const [showImportDrawer, setShowImportDrawer] = useState(false);
 
   const notify = useCallback((message: string, type: 'success' | 'error' | 'info' = 'info') => {
     if (onShowToast) {
@@ -84,7 +84,7 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
         notify('Configuration copied to clipboard', 'success');
       } else {
         setImportCode(encoded);
-        setShowImportSection(true);
+        setShowImportDrawer(true);
         setImportError('Clipboard access was blocked. The configuration code is now in the import field for manual copying.');
         notify('Clipboard access was blocked. The configuration code has been added to the import field.', 'error');
       }
@@ -154,7 +154,7 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
     setPendingImport(null);
     setPreviewOpen(false);
     setImportingConfig(true);
-    setShowImportSection(true);
+    setShowImportDrawer(true);
 
     try {
       const decodedConfig = await ConfigurationEncoder.decode(importCode.trim());
@@ -220,6 +220,8 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
       }
 
       setImportError(null);
+      setShowImportDrawer(false);
+      setShowAddSite(false);
       notify('Configuration imported successfully', 'success');
       setPreviewOpen(false);
       setPendingImport(null);
@@ -616,30 +618,17 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
 
         {/* Custom Sites */}
         <div>
-          <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-3">
             <h3 className="font-medium text-gray-900 dark:text-gray-100 text-sm">
               Custom Sites
             </h3>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <button
                 type="button"
-                onClick={() => { setShowImportSection(prev => !prev); }}
-                aria-expanded={showImportSection}
-                className={`flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors ${
-                  showImportSection
-                    ? 'border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600'
-                    : 'border-purple-200 dark:border-purple-700 text-purple-600 dark:text-purple-300 bg-white dark:bg-gray-800 hover:bg-purple-50 dark:hover:bg-purple-900/20'
-                }`}
-                title={showImportSection ? 'Hide import tools' : 'Show import tools'}
-              >
-                <svg className={`w-3.5 h-3.5 ${showImportSection ? 'transform rotate-180' : ''}`} fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-                {showImportSection ? 'Hide Import' : 'Import Configuration'}
-              </button>
-              <button
-                type="button"
-                onClick={() => { setShowAddSite(true); }}
+                onClick={() => {
+                  setShowAddSite(true);
+                  setShowImportDrawer(false);
+                }}
                 disabled={!isPickerWindow && isCurrentSiteIntegrated}
                 className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
                   !isPickerWindow && isCurrentSiteIntegrated
@@ -655,11 +644,74 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
                 </svg>
-                {!isPickerWindow && isCurrentSiteIntegrated ? 'Site Already Added' : 'Add Site'}
+                {!isPickerWindow && isCurrentSiteIntegrated ? 'Site Already Added' : 'New Custom Site'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowImportDrawer((prev) => {
+                    const next = !prev;
+                    if (next) {
+                      setShowAddSite(false);
+                    }
+                    return next;
+                  });
+                }}
+                className={`flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-lg border transition-colors ${
+                  showImportDrawer
+                    ? 'border-purple-300 dark:border-purple-600 bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-200'
+                    : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+                }`}
+                aria-expanded={showImportDrawer}
+                aria-controls="custom-site-import-drawer"
+              >
+                <svg className={`w-3.5 h-3.5 transition-transform ${showImportDrawer ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+                {showImportDrawer ? 'Hide Import' : 'Import Configuration'}
               </button>
             </div>
           </div>
 
+          {showImportDrawer && (
+            <div
+              id="custom-site-import-drawer"
+              className="mb-4 rounded-xl border border-purple-200 dark:border-purple-700 bg-purple-50/60 dark:bg-purple-900/20 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h4 className="text-sm font-semibold text-purple-800 dark:text-purple-200">Import Shared Configuration</h4>
+                  <p className="text-xs text-purple-700/80 dark:text-purple-200/70 mt-1">
+                    Reuse someone else&apos;s setup by pasting their configuration code below.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => { setShowImportDrawer(false); }}
+                  className="text-purple-700 dark:text-purple-200 hover:text-purple-900 dark:hover:text-purple-100"
+                  aria-label="Close import drawer"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <ImportSection
+                value={importCode}
+                onChange={(value) => {
+                  setImportCode(value);
+                  setImportError(null);
+                }}
+                onPreview={() => { void handlePreviewImport(); }}
+                onClear={() => {
+                  handleClearImport();
+                  setShowImportDrawer(false);
+                }}
+                loading={importingConfig}
+                error={importError}
+              />
+            </div>
+          )}
           {/* Add Site Form */}
           {showAddSite && (
             <div className="mb-3 p-4 bg-purple-50 dark:bg-purple-900/20 border-2 border-purple-200 dark:border-purple-800 rounded-lg">
@@ -952,39 +1004,21 @@ const SiteIntegrationSection: FC<SiteIntegrationSectionProps> = ({
                     {!isPickerWindow && isCurrentSiteIntegrated ? 'Current Site Already Added' : 'Add Your First Site'}
                   </button>
                 </div>
-                {showImportSection && (
-                  <div className="mt-4">
-                    <ImportSection
-                      value={importCode}
-                      onChange={(value) => {
-                        setImportCode(value);
-                        setImportError(null);
-                      }}
-                      onPreview={() => { void handlePreviewImport(); }}
-                      onClear={handleClearImport}
-                      loading={importingConfig}
-                      error={importError}
-                    />
-                  </div>
-                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowImportDrawer(true);
+                    setShowAddSite(false);
+                  }}
+                  className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-700 dark:text-purple-300 dark:hover:text-purple-200"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                  </svg>
+                  Prefer to import a configuration?
+                </button>
               </>
             )
-          )}
-
-          {customSites.length > 0 && showImportSection && (
-            <div className="mt-4">
-              <ImportSection
-                value={importCode}
-                onChange={(value) => {
-                  setImportCode(value);
-                  setImportError(null);
-                }}
-                onPreview={() => { void handlePreviewImport(); }}
-                onClear={handleClearImport}
-                loading={importingConfig}
-                error={importError}
-              />
-            </div>
           )}
         </div>
       </div>

--- a/src/components/settings/__tests__/SiteIntegrationSection.test.tsx
+++ b/src/components/settings/__tests__/SiteIntegrationSection.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+import type { CustomSite } from '../../../types';
+import SiteIntegrationSection from '../SiteIntegrationSection';
+
+const baseSiteConfigs = {
+  'claude.ai': {
+    name: 'Claude.ai',
+    description: 'Claude integration',
+    icon: <span>Claude</span>
+  }
+};
+
+const noopAsync = async () => {};
+
+const defaultProps = {
+  enabledSites: [],
+  customSites: [] as CustomSite[],
+  siteConfigs: baseSiteConfigs,
+  onSiteToggle: vi.fn(),
+  onCustomSiteToggle: vi.fn(),
+  onRemoveCustomSite: vi.fn(),
+  onAddCustomSite: noopAsync,
+  onEditCustomSite: vi.fn(),
+  interfaceMode: 'popup' as const,
+  saving: false,
+  onShowToast: vi.fn()
+};
+
+const getAddCardButton = () => screen.queryByLabelText('Add new custom site integration');
+
+describe('SiteIntegrationSection - Custom Sites UI', () => {
+  beforeEach(() => {
+    const tabsQueryMock = chrome.tabs.query as unknown as Mock;
+    tabsQueryMock.mockResolvedValue([]);
+  });
+
+  it('renders the add custom site card when custom sites exist', async () => {
+    const customSites: CustomSite[] = [
+      {
+        hostname: 'custom.ai',
+        displayName: 'Custom AI',
+        enabled: true,
+        dateAdded: Date.now()
+      }
+    ];
+
+    render(<SiteIntegrationSection {...defaultProps} customSites={customSites} />);
+
+    const addCardButton = await screen.findByLabelText('Add new custom site integration');
+    expect(addCardButton).toBeInTheDocument();
+    expect(screen.queryByText('New Custom Site')).not.toBeInTheDocument();
+  });
+
+  it('keeps the header button when no custom sites exist', () => {
+    render(<SiteIntegrationSection {...defaultProps} customSites={[]} />);
+
+    expect(getAddCardButton()).not.toBeInTheDocument();
+    expect(screen.getByText('New Custom Site')).toBeInTheDocument();
+    expect(screen.getByText('Add Your First Site')).toBeInTheDocument();
+  });
+
+  it('disables the add custom site card when the current site is already integrated', async () => {
+    const customSites: CustomSite[] = [
+      {
+        hostname: 'example.com',
+        displayName: 'Example',
+        enabled: true,
+        dateAdded: Date.now()
+      }
+    ];
+
+    const tabsQueryMock = chrome.tabs.query as unknown as Mock;
+    tabsQueryMock.mockResolvedValue([
+      {
+        id: 1,
+        url: 'https://example.com/page',
+        title: 'Example'
+      }
+    ] as chrome.tabs.Tab[]);
+
+    render(<SiteIntegrationSection {...defaultProps} customSites={customSites} />);
+
+    const addCardButton = await screen.findByLabelText('Add new custom site integration');
+
+    await waitFor(() => {
+      expect(addCardButton).toBeDisabled();
+    });
+
+    expect(addCardButton).toHaveAttribute('title', 'Current site (example.com) is already integrated');
+  });
+});

--- a/src/components/settings/__tests__/SiteIntegrationSection.test.tsx
+++ b/src/components/settings/__tests__/SiteIntegrationSection.test.tsx
@@ -54,11 +54,11 @@ describe('SiteIntegrationSection - Custom Sites UI', () => {
     expect(screen.queryByText('New Custom Site')).not.toBeInTheDocument();
   });
 
-  it('keeps the header button when no custom sites exist', () => {
+  it('does not render header button when no custom sites exist', () => {
     render(<SiteIntegrationSection {...defaultProps} customSites={[]} />);
 
     expect(getAddCardButton()).not.toBeInTheDocument();
-    expect(screen.getByText('New Custom Site')).toBeInTheDocument();
+    expect(screen.queryByText('New Custom Site')).not.toBeInTheDocument();
     expect(screen.getByText('Add Your First Site')).toBeInTheDocument();
   });
 

--- a/src/services/__tests__/configurationEncoder.test.ts
+++ b/src/services/__tests__/configurationEncoder.test.ts
@@ -1,0 +1,108 @@
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+import { describe, expect, it } from 'vitest';
+
+import type { CustomSite, CustomSiteConfiguration } from '../../types';
+import { ConfigurationEncoder, ConfigurationEncoderError } from '../configurationEncoder';
+
+describe('ConfigurationEncoder', () => {
+  const baseCustomSite: CustomSite = {
+    hostname: 'example.com',
+    displayName: 'Example Site',
+    enabled: true,
+    dateAdded: Date.now(),
+    positioning: {
+      mode: 'custom',
+      selector: '#prompt-input',
+      placement: 'inside-end',
+      offset: { x: 12, y: -4 },
+      zIndex: 1500,
+      description: 'Place widget near the footer'
+    }
+  };
+
+  it('encodes and decodes a configuration preserving core fields', async () => {
+    const encoded = await ConfigurationEncoder.encode(baseCustomSite);
+    expect(typeof encoded).toBe('string');
+    expect(encoded.length).toBeGreaterThan(0);
+
+    const decoded = await ConfigurationEncoder.decode(encoded);
+
+    const expected: CustomSiteConfiguration = {
+      hostname: 'example.com',
+      displayName: 'Example Site',
+      positioning: {
+        mode: 'custom',
+        selector: '#prompt-input',
+        placement: 'inside-end',
+        offset: { x: 12, y: -4 },
+        zIndex: 1500,
+        description: 'Place widget near the footer'
+      }
+    };
+
+    expect(decoded).toEqual(expected);
+  });
+
+  it('rejects invalid encoded strings', async () => {
+    await expect(ConfigurationEncoder.decode('not-a-valid-code')).rejects.toMatchObject({
+      code: 'INVALID_FORMAT'
+    });
+  });
+
+  it('detects tampered payloads using checksum', async () => {
+    const encoded = await ConfigurationEncoder.encode(baseCustomSite);
+    const serialized = decompressFromEncodedURIComponent(encoded);
+    if (!serialized) {
+      throw new Error('Failed to decompress test payload');
+    }
+    const payload = JSON.parse(serialized) as Record<string, unknown>;
+    payload.n = 'Tampered Name';
+    const tampered = compressToEncodedURIComponent(JSON.stringify(payload));
+
+    await expect(ConfigurationEncoder.decode(tampered)).rejects.toMatchObject({
+      code: 'CHECKSUM_FAILED'
+    });
+  });
+
+  it('blocks configurations with unsafe selectors', async () => {
+    const maliciousSite: CustomSite = {
+      ...baseCustomSite,
+      positioning: {
+        mode: 'custom',
+        selector: 'input[href="javascript:alert(1)"]',
+        placement: 'before'
+      }
+    };
+
+    try {
+      await ConfigurationEncoder.encode(maliciousSite);
+      throw new Error('Expected encoding to fail for unsafe selector');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationEncoderError);
+      expect(['SECURITY_VIOLATION', 'VALIDATION_ERROR']).toContain((error as ConfigurationEncoderError).code);
+    }
+  });
+
+  it('reports validation issues for incomplete payloads', () => {
+    const config: CustomSiteConfiguration = {
+      hostname: '',
+      displayName: '',
+      positioning: {
+        mode: 'custom',
+        selector: '',
+        placement: 'before'
+      }
+    };
+
+    const result = ConfigurationEncoder.validate(config);
+
+    expect(result.isValid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'hostname' }),
+        expect.objectContaining({ field: 'displayName' }),
+        expect.objectContaining({ field: 'positioning.selector' })
+      ])
+    );
+  });
+});

--- a/src/services/configurationEncoder.ts
+++ b/src/services/configurationEncoder.ts
@@ -1,0 +1,374 @@
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+
+import {
+  CustomSite,
+  CustomSiteConfiguration,
+  ConfigurationValidationResult,
+  EncodedCustomSitePayloadV1,
+  SecurityWarning
+} from '../types';
+import {
+  detectMaliciousContent,
+  isSelectorSafe,
+  sanitizeConfiguration,
+  HOSTNAME_PATTERN
+} from '../utils/configurationSecurity';
+
+type NormalizedPayload = Omit<EncodedCustomSitePayloadV1, 'c'>;
+
+type ConfigurationErrorCode =
+  | 'INVALID_FORMAT'
+  | 'UNSUPPORTED_VERSION'
+  | 'CHECKSUM_FAILED'
+  | 'SECURITY_VIOLATION'
+  | 'VALIDATION_ERROR';
+
+export class ConfigurationEncoderError extends Error {
+  public readonly code: ConfigurationErrorCode;
+
+  constructor(message: string, code: ConfigurationErrorCode) {
+    super(message);
+    this.name = 'ConfigurationEncoderError';
+    this.code = code;
+  }
+}
+
+const CURRENT_VERSION = '1.0';
+const VALID_PLACEMENTS: Array<NonNullable<CustomSite['positioning']>['placement']> = [
+  'before',
+  'after',
+  'inside-start',
+  'inside-end'
+];
+
+const canonicalizePayload = (payload: NormalizedPayload): string => {
+  const canonical: NormalizedPayload = {
+    v: payload.v,
+    h: payload.h,
+    n: payload.n
+  };
+
+  if (payload.p) {
+    canonical.p = {
+      s: payload.p.s,
+      pl: payload.p.pl
+    };
+
+    if (payload.p.ox !== undefined) {
+      canonical.p.ox = payload.p.ox;
+    }
+    if (payload.p.oy !== undefined) {
+      canonical.p.oy = payload.p.oy;
+    }
+    if (payload.p.z !== undefined) {
+      canonical.p.z = payload.p.z;
+    }
+    if (payload.p.d !== undefined) {
+      canonical.p.d = payload.p.d;
+    }
+  }
+
+  return JSON.stringify(canonical);
+};
+
+const arrayBufferToHex = (buffer: ArrayBuffer): string => {
+  const byteArray = new Uint8Array(buffer);
+  return Array.from(byteArray)
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+const getSubtleCrypto = (): SubtleCrypto | null => {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+
+  const potentialCrypto = (globalThis as { crypto?: Crypto }).crypto;
+  return typeof potentialCrypto?.subtle !== 'undefined' ? potentialCrypto.subtle : null;
+};
+
+const computeChecksum = async (value: string): Promise<string> => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(value);
+
+  const subtle = getSubtleCrypto();
+  if (subtle) {
+    const digest = await subtle.digest('SHA-256', data);
+    return arrayBufferToHex(digest).slice(0, 16);
+  }
+
+  // Fallback checksum (non-cryptographic) for environments without Web Crypto
+  let hash = 0;
+  for (const byte of data) {
+    hash = (hash * 31 + byte) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+};
+
+const configToPayload = (config: CustomSiteConfiguration): NormalizedPayload => {
+  const payload: NormalizedPayload = {
+    v: CURRENT_VERSION,
+    h: config.hostname,
+    n: config.displayName
+  };
+
+  if (config.positioning && config.positioning.selector) {
+    payload.p = {
+      s: config.positioning.selector,
+      pl: config.positioning.placement
+    };
+
+    if (config.positioning.offset) {
+      const { x, y } = config.positioning.offset;
+      if (x !== 0) {
+        payload.p.ox = x;
+      }
+      if (y !== 0) {
+        payload.p.oy = y;
+      }
+    }
+
+    if (config.positioning.zIndex !== undefined) {
+      payload.p.z = config.positioning.zIndex;
+    }
+
+    if (config.positioning.description) {
+      payload.p.d = config.positioning.description;
+    }
+  }
+
+  return payload;
+};
+
+const payloadToConfig = (payload: NormalizedPayload): CustomSiteConfiguration => {
+  const config: CustomSiteConfiguration = {
+    hostname: payload.h,
+    displayName: payload.n
+  };
+
+  if (payload.p) {
+    const placement = payload.p.pl;
+    const selector = payload.p.s;
+
+    if (VALID_PLACEMENTS.includes(placement) && typeof selector === 'string' && selector.trim().length > 0) {
+      config.positioning = {
+        mode: 'custom',
+        selector,
+        placement,
+        offset: payload.p.ox !== undefined || payload.p.oy !== undefined ? {
+          x: payload.p.ox ?? 0,
+          y: payload.p.oy ?? 0
+        } : undefined,
+        zIndex: payload.p.z,
+        description: payload.p.d
+      };
+    }
+  }
+
+  return config;
+};
+
+const raiseSecurityError = (warnings: SecurityWarning[]): never => {
+  const message = warnings.map(warning => `${warning.field}: ${warning.message}`).join('\n');
+  throw new ConfigurationEncoderError(message || 'Configuration failed security validation', 'SECURITY_VIOLATION');
+};
+
+const validateConfiguration = (config: CustomSiteConfiguration): ConfigurationValidationResult => {
+  const sanitizedConfig = sanitizeConfiguration(config);
+  const warnings = detectMaliciousContent(sanitizedConfig);
+
+  const issues: ConfigurationValidationResult['issues'] = [];
+
+  if (!sanitizedConfig.hostname) {
+    issues.push({
+      field: 'hostname',
+      message: 'Hostname is required.',
+      severity: 'error'
+    });
+  } else if (!HOSTNAME_PATTERN.test(sanitizedConfig.hostname)) {
+    issues.push({
+      field: 'hostname',
+      message: 'Hostname must be a valid public domain.',
+      severity: 'error'
+    });
+  }
+
+  if (!sanitizedConfig.displayName) {
+    issues.push({
+      field: 'displayName',
+      message: 'Display name is required.',
+      severity: 'error'
+    });
+  }
+
+  if (sanitizedConfig.positioning) {
+    if (!sanitizedConfig.positioning.selector) {
+      issues.push({
+        field: 'positioning.selector',
+        message: 'Selector is required when positioning is provided.',
+        severity: 'error'
+      });
+    } else if (!isSelectorSafe(sanitizedConfig.positioning.selector)) {
+      issues.push({
+        field: 'positioning.selector',
+        message: 'Selector contains unsafe characters or patterns.',
+        severity: 'error'
+      });
+    }
+
+    if (!VALID_PLACEMENTS.includes(sanitizedConfig.positioning.placement)) {
+      issues.push({
+        field: 'positioning.placement',
+        message: 'Placement is not supported.',
+        severity: 'error'
+      });
+    }
+
+    if (sanitizedConfig.positioning.offset) {
+      const { x, y } = sanitizedConfig.positioning.offset;
+      if (!Number.isFinite(x) || Math.abs(x) > 500) {
+        issues.push({
+          field: 'positioning.offset.x',
+          message: 'Offset X must be between -500 and 500.',
+          severity: 'error'
+        });
+      }
+      if (!Number.isFinite(y) || Math.abs(y) > 500) {
+        issues.push({
+          field: 'positioning.offset.y',
+          message: 'Offset Y must be between -500 and 500.',
+          severity: 'error'
+        });
+      }
+    }
+
+    if (sanitizedConfig.positioning.zIndex !== undefined) {
+      const z = sanitizedConfig.positioning.zIndex;
+      if (!Number.isInteger(z) || z < 0 || z > 2147483647) {
+        issues.push({
+          field: 'positioning.zIndex',
+          message: 'Z-index must be an integer between 0 and 2147483647.',
+          severity: 'error'
+        });
+      }
+    }
+  }
+
+  const isValid = issues.every(issue => issue.severity !== 'error') && warnings.every(warning => warning.severity !== 'error');
+
+  return {
+    isValid,
+    issues,
+    warnings,
+    sanitizedConfig
+  };
+};
+
+const encode = async (customSite: CustomSite): Promise<string> => {
+  const rawConfig: CustomSiteConfiguration = {
+    hostname: customSite.hostname,
+    displayName: customSite.displayName,
+    positioning: customSite.positioning
+      ? {
+          ...customSite.positioning,
+          offset: customSite.positioning.offset
+            ? { ...customSite.positioning.offset }
+            : undefined
+        }
+      : undefined
+  };
+
+  const validation = validateConfiguration(rawConfig);
+
+  if (!validation.isValid) {
+    const issues = validation.issues.filter(issue => issue.severity === 'error');
+    const message = issues.map(issue => `${issue.field}: ${issue.message}`).join('\n') || 'Configuration is invalid';
+    throw new ConfigurationEncoderError(message, 'VALIDATION_ERROR');
+  }
+
+  const blockingWarnings = validation.warnings.filter(warning => warning.severity === 'error');
+  if (blockingWarnings.length > 0) {
+    raiseSecurityError(blockingWarnings);
+  }
+
+  const payload = configToPayload(validation.sanitizedConfig);
+  const canonical = canonicalizePayload(payload);
+  const checksum = await computeChecksum(canonical);
+
+  const encodedPayload: EncodedCustomSitePayloadV1 = {
+    ...payload,
+    c: checksum
+  };
+
+  const serialized = JSON.stringify(encodedPayload);
+  const encoded = compressToEncodedURIComponent(serialized);
+
+  if (!encoded) {
+    throw new ConfigurationEncoderError('Failed to encode configuration', 'INVALID_FORMAT');
+  }
+
+  return encoded;
+};
+
+const decode = async (encodedString: string): Promise<CustomSiteConfiguration> => {
+  if (!encodedString || encodedString.trim().length === 0) {
+    throw new ConfigurationEncoderError('Configuration code is empty', 'INVALID_FORMAT');
+  }
+
+  let serialized: string | null;
+  try {
+    serialized = decompressFromEncodedURIComponent(encodedString.trim());
+  } catch (error) {
+    console.error('Failed to decompress configuration string:', error);
+    serialized = null;
+  }
+
+  if (!serialized) {
+    throw new ConfigurationEncoderError('Invalid configuration code', 'INVALID_FORMAT');
+  }
+
+  let payload: EncodedCustomSitePayloadV1;
+  try {
+    payload = JSON.parse(serialized) as EncodedCustomSitePayloadV1;
+  } catch (error) {
+    console.error('Failed to parse configuration payload:', error);
+    throw new ConfigurationEncoderError('Invalid configuration format', 'INVALID_FORMAT');
+  }
+
+  if (payload.v !== CURRENT_VERSION) {
+    throw new ConfigurationEncoderError('Unsupported configuration version', 'UNSUPPORTED_VERSION');
+  }
+
+  const { c: receivedChecksum, ...rest } = payload;
+  const canonical = canonicalizePayload(rest);
+  const expectedChecksum = await computeChecksum(canonical);
+
+  if (receivedChecksum !== expectedChecksum) {
+    throw new ConfigurationEncoderError('Configuration checksum mismatch', 'CHECKSUM_FAILED');
+  }
+
+  const decodedConfig = payloadToConfig(rest);
+  const validation = validateConfiguration(decodedConfig);
+
+  if (!validation.isValid) {
+    const issues = validation.issues.filter(issue => issue.severity === 'error');
+    const message = issues.map(issue => `${issue.field}: ${issue.message}`).join('\n') || 'Configuration is invalid';
+    throw new ConfigurationEncoderError(message, 'VALIDATION_ERROR');
+  }
+
+  const blockingWarnings = validation.warnings.filter(warning => warning.severity === 'error');
+  if (blockingWarnings.length > 0) {
+    raiseSecurityError(blockingWarnings);
+  }
+
+  return validation.sanitizedConfig;
+};
+
+const ConfigurationEncoder = {
+  encode,
+  decode,
+  validate: validateConfiguration
+} as const;
+
+export { ConfigurationEncoder };
+export type { ConfigurationErrorCode };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,7 +13,21 @@ const mockChrome = {
     }
   },
   runtime: {
-    lastError: null
+    lastError: null,
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    onMessage: {
+      addListener: vi.fn(),
+      removeListener: vi.fn()
+    }
+  },
+  permissions: {
+    request: vi.fn().mockResolvedValue(false),
+    contains: vi.fn().mockResolvedValue(false),
+    remove: vi.fn().mockResolvedValue(undefined)
+  },
+  tabs: {
+    query: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(undefined)
   }
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,48 @@ export interface CustomSite {
   };
 }
 
+export type CustomSitePositioning = NonNullable<CustomSite['positioning']>;
+
+export interface CustomSiteConfiguration {
+  hostname: string;
+  displayName: string;
+  positioning?: CustomSitePositioning;
+}
+
+export interface SecurityWarning {
+  field: string;
+  message: string;
+  severity: 'warning' | 'error';
+}
+
+export interface ConfigurationValidationIssue {
+  field: string;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface ConfigurationValidationResult {
+  isValid: boolean;
+  issues: ConfigurationValidationIssue[];
+  warnings: SecurityWarning[];
+  sanitizedConfig: CustomSiteConfiguration;
+}
+
+export interface EncodedCustomSitePayloadV1 {
+  v: string;
+  h: string;
+  n: string;
+  p?: {
+    s: string;
+    pl: CustomSitePositioning['placement'];
+    ox?: number;
+    oy?: number;
+    z?: number;
+    d?: string;
+  };
+  c: string;
+}
+
 // UI state interfaces
 export interface AppState {
   prompts: Prompt[];

--- a/src/utils/configurationSecurity.ts
+++ b/src/utils/configurationSecurity.ts
@@ -1,0 +1,126 @@
+import DOMPurify from 'dompurify';
+
+import {
+  CustomSiteConfiguration,
+  CustomSitePositioning,
+  SecurityWarning
+} from '../types';
+
+const MAX_OFFSET = 500;
+const MAX_Z_INDEX = 2147483647;
+export const HOSTNAME_PATTERN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
+const UNSAFE_SELECTOR_PATTERNS: RegExp[] = [
+  /javascript\s*:/i,
+  /vbscript\s*:/i,
+  /expression\s*\(/i,
+  /behaviour\s*:/i,
+  /url\s*\(\s*["']?\s*javascript:/i,
+  /[`]/,
+  /on[a-z]+\s*=\s*/i,
+  /</
+];
+
+const CONTROL_CHARACTER_PATTERN = /[\r\n\t]/;
+const NULL_CHARACTER = String.fromCharCode(0);
+
+const sanitizeText = (value: string): string => {
+  return DOMPurify.sanitize(value, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim();
+};
+
+const clampNumber = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const sanitizePositioning = (positioning: CustomSitePositioning): CustomSitePositioning => {
+  const selector = sanitizeText(positioning.selector);
+  const sanitized: CustomSitePositioning = {
+    mode: 'custom',
+    selector,
+    placement: positioning.placement,
+    offset: positioning.offset ? {
+      x: clampNumber(positioning.offset.x, -MAX_OFFSET, MAX_OFFSET),
+      y: clampNumber(positioning.offset.y, -MAX_OFFSET, MAX_OFFSET)
+    } : undefined,
+    zIndex: positioning.zIndex !== undefined ? clampNumber(positioning.zIndex, 0, MAX_Z_INDEX) : undefined,
+    description: positioning.description ? sanitizeText(positioning.description).slice(0, 160) : undefined
+  };
+
+  if (sanitized.offset && sanitized.offset.x === 0 && sanitized.offset.y === 0) {
+    delete sanitized.offset;
+  }
+
+  if (sanitized.selector.length === 0) {
+    delete sanitized.selector;
+  }
+
+  if (sanitized.zIndex === 0) {
+    delete sanitized.zIndex;
+  }
+
+  return sanitized;
+};
+
+export const isSelectorSafe = (selector: string): boolean => {
+  if (!selector || selector.trim().length === 0) {
+    return false;
+  }
+
+  if (selector.length > 300) {
+    return false;
+  }
+
+  if (CONTROL_CHARACTER_PATTERN.test(selector) || selector.includes(NULL_CHARACTER)) {
+    return false;
+  }
+
+  return !UNSAFE_SELECTOR_PATTERNS.some((pattern) => pattern.test(selector));
+};
+
+export const sanitizeConfiguration = (config: CustomSiteConfiguration): CustomSiteConfiguration => {
+  const hostname = sanitizeText(config.hostname).toLowerCase();
+  const displayName = sanitizeText(config.displayName).slice(0, 80);
+
+  const sanitizedConfig: CustomSiteConfiguration = {
+    hostname,
+    displayName
+  };
+
+  if (config.positioning) {
+    sanitizedConfig.positioning = sanitizePositioning(config.positioning);
+  }
+
+  return sanitizedConfig;
+};
+
+export const detectMaliciousContent = (config: CustomSiteConfiguration): SecurityWarning[] => {
+  const warnings: SecurityWarning[] = [];
+
+  if (!HOSTNAME_PATTERN.test(config.hostname)) {
+    warnings.push({
+      field: 'hostname',
+      message: 'Hostname does not look like a valid public domain.',
+      severity: 'error'
+    });
+  }
+
+  if (config.positioning?.selector && !isSelectorSafe(config.positioning.selector)) {
+    warnings.push({
+      field: 'positioning.selector',
+      message: 'Selector contains potentially unsafe patterns.',
+      severity: 'error'
+    });
+  }
+
+  if (config.positioning?.description && config.positioning.description.length > 160) {
+    warnings.push({
+      field: 'positioning.description',
+      message: 'Description is too long and was truncated for safety.',
+      severity: 'warning'
+    });
+  }
+
+  return warnings;
+};


### PR DESCRIPTION
## Summary
- add encoding service with compression, checksum verification, and security vetting for custom site exports
- expose export actions on custom site cards and document the sharing workflow for non-technical users
- build guided import flow with preview modal, duplicate handling, and permission prompts directly in settings
- modernize custom site UI (action card, method chooser) and land supporting specs/steering notes

## Implementation Notes
- introduce `ConfigurationEncoder` plus `configurationSecurity` utilities to sanitize imports/exports and detect tampering
- extend `SiteIntegrationSection` with import/export state management, clipboard fallback, and chrome permission requests
- add `ConfigurationPreview`, `ImportSection`, `ExportButton`, and `AddCustomSiteCard` components to streamline the UX
- update background script to respect new permissions and ensure injected scripts activate for freshly imported sites
- capture product/engineering intent in `.kiro` steering docs and ship a user-facing guide in `docs/CUSTOM_SITES_USER_GUIDE.md`

## Testing
- added: unit coverage for encoder happy path, checksum failure, unsafe selectors, and validation issues
- added: integration-style tests covering new custom site card behavior and active-tab disable states
- not run in this session (run `npm test` locally before merge)

## Follow-ups
- consider splitting `SiteIntegrationSection` state into smaller hooks as import/export logic evolves
- monitor clipboard access failures in production to decide if we need a dedicated copy permission flow
