### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Prompt Manager - Chrome Extension
 
-[![Version](https://img.shields.io/badge/version-1.2.1-blue.svg)](https://github.com/spartDev/My-Prompt-Manager)
+[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/spartDev/My-Prompt-Manager)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Chrome](https://img.shields.io/badge/Chrome-114%2B-yellow.svg)](https://www.google.com/chrome/)
 [![Tests](https://img.shields.io/badge/tests-470%20passing-brightgreen.svg)](https://github.com/spartDev/My-Prompt-Manager)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "My Prompt Manager",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Store, organize, and quickly access your personal collection of text prompts with categories and search functionality.",
   "author": "Thomas Roux",
   "homepage_url": "https://github.com/spartDev/My-Prompt-Manager",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prompt-library-extension",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prompt-library-extension",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@types/dompurify": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-library-extension",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Chrome extension for managing personal prompt library",
   "license": "MIT",
   "type": "module",

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -453,7 +453,7 @@ const SettingsView: FC<SettingsViewProps> = ({ onBack, showToast }) => {
 
           {/* About & Reset Section */}
           <AboutSection
-            version="1.2.1"
+            version="1.3.0"
             onReset={handleResetSettings}
           />
         </div>


### PR DESCRIPTION
Summary
- Bump extension version from 1.2.1 to 1.3.0 following semantic versioning.
- Reasoning: Since 1.2.1 there are multiple new features and notable enhancements (no breaking changes), warranting a minor version increase.

Files Updated
- package.json → 1.3.0
- package-lock.json → 1.3.0 (via `npm version 1.3.0 --no-git-tag-version`)
- manifest.json → 1.3.0 (Chrome Web Store critical version)
- README.md → Update badge to 1.3.0
- src/components/SettingsView.tsx → Update About section display to 1.3.0

Change Highlights Since 1.2.1 (non-breaking)
- Testing/CI:
  - Add/expand Playwright E2E coverage and CI reliability improvements
  - Separate unit vs E2E test runners to avoid conflicts
  - Improve CI browser installation, caching, and stability
- Security & Injection:
  - Programmatic content script injection with targeted permissions
  - Element picker security hardening (sensitive field/domain protections, audit logging, sanitization)
- UX & Functionality:
  - Settings UI refinements and improved side panel / popup handling
  - Improved site integration flows and custom site management
  - Better error handling, logging, and cleanup behavior across contexts

Verification Checklist
- [x] Version updated consistently across user-facing locations
- [x] Build succeeds locally (`npm run build`)
- [x] Unit tests pass locally (`npm test`)
- [x] E2E tests pass locally where applicable (`npm run test:e2e`)
- [x] Extension loads in Chrome with version 1.3.0 in `chrome://extensions`

Release Notes
- Minor release with new features, UX improvements, and security hardening; no breaking changes.

Notes
- After merge, the Chrome extension package should include the updated `manifest.json` version for store submission.
