### PR TITLE
fix: Fix custom-site element picker by restoring content bundle access

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,19 @@
       "all_frames": false
     }
   ],
+  "web_accessible_resources": [
+    {
+      "matches": [
+        "https://*/*",
+        "http://*/*"
+      ],
+      "resources": [
+        "assets/content-*.js",
+        "assets/platforms-*.js"
+      ],
+      "use_dynamic_url": false
+    }
+  ],
   "optional_host_permissions": [
     "https://*/*",
     "http://*/*"


### PR DESCRIPTION
# Summary

- Added a web_accessible_resources entry that exposes the compiled content and platform bundles `(assets/content-*.js, assets/platforms-*.js)` to every `https:///http://` origin a user grants.
- Restored the ability for the loader `(assets/index.ts-loader-*.js)` to `import()` those bundles on custom domains, which was blocked after the 1.4.0 manifest tightened host matches for the Mistral release.
- With the content script booting again on custom sites, the element picker and prompt-injection flows no longer fail on manually added hosts.