### PR TITLE
refactor(PromptCard): Convert copy button to icon-only design

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -238,6 +238,7 @@ type IconType = 'logo' | 'add' | 'edit' | 'settings';
 - **Search highlighting** with stable React keys
 - **Full keyboard navigation** with arrow keys
 - **Dropdown menu** with accessibility
+- **Icon-only action buttons** for clean, minimal design
 
 **Props:**
 ```typescript
@@ -272,6 +273,11 @@ const sanitizedText = DOMPurify.sanitize(text, {
   ALLOWED_ATTR: []
 });
 ```
+
+**Actions:**
+- **Copy button**: Icon-only design matching menu button aesthetics (gray with purple hover)
+- **Menu button**: 3-dot dropdown for Edit/Delete actions
+- Both buttons use consistent icon-button styling pattern for visual harmony
 
 **File:** `src/components/PromptCard.tsx:1-357`
 

--- a/src/components/PromptCard.tsx
+++ b/src/components/PromptCard.tsx
@@ -170,7 +170,7 @@ const PromptCard: FC<PromptCardProps> = ({
         </div>
         
         {/* Actions */}
-        <div className="flex items-center space-x-1 flex-shrink-0">
+        <div className="flex items-center space-x-2 flex-shrink-0">
           {/* Copy Button */}
           <button
             onClick={handleCopyClick}
@@ -180,10 +180,11 @@ const PromptCard: FC<PromptCardProps> = ({
                 handleCopyClick();
               }
             }}
-            className="inline-flex items-center px-2 py-1 bg-gradient-to-r from-purple-500 to-indigo-500 text-white rounded-md hover:from-purple-600 hover:to-indigo-600 transition-all duration-200 text-xs font-medium focus-primary"
+            className="p-2 text-gray-400 dark:text-gray-500 hover:text-purple-600 dark:hover:text-purple-400 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors focus-interactive"
             aria-label={`Copy content of ${prompt.title} to clipboard`}
+            title="Copy to clipboard"
           >
-            <svg className="h-3 w-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -191,7 +192,6 @@ const PromptCard: FC<PromptCardProps> = ({
                 d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
               />
             </svg>
-            Copy
           </button>
 
           {/* Menu */}

--- a/src/components/__tests__/PromptCard.test.tsx
+++ b/src/components/__tests__/PromptCard.test.tsx
@@ -57,7 +57,7 @@ describe('PromptCard - Basic Rendering', () => {
 
   it('should render copy button', () => {
     render(<PromptCard {...mockProps} />);
-    expect(screen.getByText('Copy')).toBeInTheDocument();
+    expect(screen.getByLabelText(/copy.*to clipboard/i)).toBeInTheDocument();
   });
 
   it('should apply truncate styles to long titles', () => {


### PR DESCRIPTION
## Summary

Refactored the copy button in `PromptCard` from a text+icon design to a minimal icon-only design that better complements the existing 3-dot menu button, reducing visual clutter while maintaining full accessibility.

## Changes

### Component Updates (SMP-46)
- **PromptCard.tsx**: Converted copy button to icon-only design
  - Removed "Copy" text label, keeping only the icon
  - Updated styling to match icon-button pattern from design guidelines
  - Changed from purple gradient background to gray with purple hover
  - Increased icon size from `h-3 w-3` to `h-4 w-4` for consistency
  - Added `title="Copy to clipboard"` for tooltip on hover
  - Adjusted container spacing from `space-x-1` to `space-x-2`

### Test Updates (SMP-47)
- **PromptCard.test.tsx**: Updated test assertion
  - Changed from querying by text content to aria-label
  - Now uses regex pattern `/copy.*to clipboard/i` for more flexible matching

### Quality Assurance (SMP-48)
- ✅ All 875 tests passing
- ✅ 0 ESLint errors
- ✅ TypeScript compilation successful

### Documentation (SMP-49)
- **COMPONENTS.md**: Documented icon-only button pattern
  - Added to Key Features list
  - Added Actions subsection explaining button styling consistency

## Design Rationale

- **Visual Consistency**: Copy button now matches the 3-dot menu button aesthetics
- **Reduced Clutter**: Icon-only design creates cleaner, more minimal UI
- **Accessibility**: Maintains full accessibility via aria-label and title attribute
- **Design System Alignment**: Follows established icon-button pattern from DESIGN_GUIDELINES.md

## Accessibility

- ✅ Comprehensive aria-label preserved: `Copy content of {title} to clipboard`
- ✅ Title attribute added for tooltip on hover
- ✅ Keyboard navigation maintained (Enter/Space key support)
- ✅ Focus styles applied via `.focus-interactive` class

## Implementation Plan

📄 **Confluence Plan**: https://spartdev.atlassian.net/wiki/spaces/MPM/pages/4194311/

## Related Issues

**Epic**: [SMP-45](https://spartdev.atlassian.net/browse/SMP-45) - Refactor PromptCard Copy Button to Icon-Only Design

**Tasks**:
- [SMP-46](https://spartdev.atlassian.net/browse/SMP-46) - Update component styles ✅
- [SMP-47](https://spartdev.atlassian.net/browse/SMP-47) - Update test assertions ✅
- [SMP-48](https://spartdev.atlassian.net/browse/SMP-48) - Run quality checks ✅
- [SMP-49](https://spartdev.atlassian.net/browse/SMP-49) - Update documentation ✅

## Screenshots

**Before**: Purple gradient button with "Copy" text + icon  
**After**: Gray icon-only button with purple hover state (matches menu button)

## Testing Checklist

- [x] Unit tests passing (875/875)
- [x] ESLint checks passing (0 errors)
- [x] TypeScript compilation successful
- [x] Manual testing in browser (copy functionality works)
- [x] Keyboard navigation tested
- [x] Dark mode compatibility verified
- [x] Accessibility (aria-label, title) verified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMP-45]: https://spartdev.atlassian.net/browse/SMP-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ