### PR TITLE
chore: remove deprecated @types/dompurify dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "1.7.4",
-        "@types/dompurify": "3.2.0",
         "dompurify": "3.2.7",
         "lz-string": "1.5.0",
         "react": "19.2.0",
@@ -2044,16 +2043,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.7.4",
-    "@types/dompurify": "3.2.0",
     "dompurify": "3.2.7",
     "lz-string": "1.5.0",
     "react": "19.2.0",


### PR DESCRIPTION
## Summary
Remove the deprecated `@types/dompurify` package from `package.json` and `package-lock.json` as DOMPurify v3.2.7 now provides built-in TypeScript type definitions, eliminating the need for a separate types package.

## Related Issues
**GitHub Issues:** N/A

## Type of Change
- [x] ♻️ Code refactoring (no functional changes)
- [x] 🔧 Configuration/build changes

## Motivation and Context
DOMPurify v3.2.7 now includes native TypeScript type definitions, making the separate `@types/dompurify` package redundant. This change:
- Streamlines dependency management by removing unnecessary packages
- Reduces the total dependency count
- Simplifies maintenance by relying on types from the upstream package

## Implementation Details

### What Changed
Removed the `@types/dompurify` devDependency which was previously required for TypeScript type support. DOMPurify's native types now provide the same functionality.

### Key Files Modified
- `package.json` - Removed `@types/dompurify` from devDependencies
- `package-lock.json` - Cleaned up lock file entries

### API/Interface Changes
No API changes. Type definitions remain the same, now sourced from DOMPurify itself instead of DefinitelyTyped.

## Breaking Changes
**Does this introduce breaking changes?** ⚠️
- [x] No - Fully backward compatible

## Testing

### Test Coverage
- [x] All existing tests pass
- [x] Code builds without errors
- [x] Lint checks pass

### How to Test Manually
```bash
npm install
npm run build
npm run typecheck
npm run lint
npm test
```

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications
- [x] Dependencies scanned for vulnerabilities

## Documentation
- [x] Code follows project style guidelines
- [x] No documentation updates needed (configuration-only change)

## Pre-Merge Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code builds without errors (`npm run build`)
- [x] All tests pass (`npm test`)
- [x] Lint checks pass (`npm run lint`)
- [x] No new warnings introduced
- [x] Commits are clean and well-described

## Additional Context
This is a routine maintenance task to keep dependencies lean and up-to-date with upstream packages that now provide their own types. No changes to source code required.