### PR TITLE
chore: remove deprecated @types/uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@types/node": "24.7.1",
         "@types/react": "19.2.2",
         "@types/react-dom": "19.2.1",
-        "@types/uuid": "11.0.0",
         "@typescript-eslint/eslint-plugin": "8.46.0",
         "@typescript-eslint/parser": "8.46.0",
         "@vitejs/plugin-react": "5.0.4",
@@ -2155,17 +2154,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/node": "24.7.1",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.1",
-    "@types/uuid": "11.0.0",
     "@typescript-eslint/eslint-plugin": "8.46.0",
     "@typescript-eslint/parser": "8.46.0",
     "@vitejs/plugin-react": "5.0.4",


### PR DESCRIPTION
## Summary
Remove the deprecated `@types/uuid` package from `package.json` and `package-lock.json` as UUID v13.0.0 now provides built-in TypeScript type definitions, eliminating the need for a separate types package.

## Related Issues
**GitHub Issues:** N/A

## Type of Change
- [x] ♻️ Code refactoring (no functional changes)
- [x] 🔧 Configuration/build changes

## Motivation and Context
UUID v13.0.0 now includes native TypeScript type definitions, making the separate `@types/uuid` package redundant. This change:
- Streamlines dependency management by removing unnecessary packages
- Reduces the total dependency count
- Simplifies maintenance by relying on types from the upstream package
- Keeps our dependencies in sync with modern best practices

## Implementation Details

### What Changed
Removed the `@types/uuid` devDependency which was previously required for TypeScript type support. UUID's native types now provide the same functionality.

### Key Files Modified
- `package.json` - Removed `@types/uuid` from devDependencies
- `package-lock.json` - Cleaned up lock file entries

### API/Interface Changes
No API changes. Type definitions remain the same, now sourced from UUID itself instead of DefinitelyTyped.

## Breaking Changes
**Does this introduce breaking changes?** ⚠️
- [x] No - Fully backward compatible

## Testing

### Test Coverage
- [x] All existing tests pass
- [x] Code builds without errors
- [x] Lint checks pass

### How to Test Manually
```bash
npm install
npm run build
npm run typecheck
npm run lint
npm test
```

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications
- [x] Dependencies scanned for vulnerabilities

## Documentation
- [x] Code follows project style guidelines
- [x] No documentation updates needed (configuration-only change)

## Pre-Merge Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code builds without errors (`npm run build`)
- [x] All tests pass (`npm test`)
- [x] Lint checks pass (`npm run lint`)
- [x] No new warnings introduced
- [x] Commits are clean and well-described

## Additional Context
This is a routine maintenance task to keep dependencies lean and up-to-date with upstream packages that now provide their own types. No changes to source code required.