### PR TITLE
feat: enhance release format with project branding and emojis

### DIFF
--- a/.claude/skills/release-automation/SKILL.md
+++ b/.claude/skills/release-automation/SKILL.md
@@ -305,7 +305,7 @@ EOF
 # Add Security section
 if [ -f /tmp/security.txt ]; then
   cat >> "$CHANGELOG_FILE" <<EOF
-### Security
+### 🔒 Security
 
 EOF
   cat /tmp/security.txt >> "$CHANGELOG_FILE"
@@ -325,7 +325,7 @@ fi
 # Add Added section
 if [ -f /tmp/added.txt ]; then
   cat >> "$CHANGELOG_FILE" <<EOF
-### Added
+### ✨ Added
 
 EOF
   cat /tmp/added.txt >> "$CHANGELOG_FILE"
@@ -335,7 +335,7 @@ fi
 # Add Changed section
 if [ -f /tmp/changed.txt ]; then
   cat >> "$CHANGELOG_FILE" <<EOF
-### Changed
+### 🔄 Changed
 
 EOF
   cat /tmp/changed.txt >> "$CHANGELOG_FILE"
@@ -345,7 +345,7 @@ fi
 # Add Fixed section
 if [ -f /tmp/fixed.txt ]; then
   cat >> "$CHANGELOG_FILE" <<EOF
-### Fixed
+### 🐛 Fixed
 
 EOF
   cat /tmp/fixed.txt >> "$CHANGELOG_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,7 +312,7 @@ jobs:
               /^## \['$version'\]/ { found=1; print; next }
               /^## \[/ { if (found) exit }
               found { print }
-            ' CHANGELOG.md > changelog-excerpt.txt
+            ' CHANGELOG.md | sed 's/^### Added/### ✨ Added/' | sed 's/^### Changed/### 🔄 Changed/' | sed 's/^### Fixed/### 🐛 Fixed/' | sed 's/^### Security/### 🔒 Security/' > changelog-excerpt.txt
 
             # Check if we found the changelog section
             if [ ! -s changelog-excerpt.txt ]; then
@@ -340,7 +340,7 @@ jobs:
             else
               # Create enhanced release notes with changelog
               cat > release-notes.md << EOF
-          # Chrome Extension v$version
+          # 🚀 My Prompt Manager v$version
 
           $(cat changelog-excerpt.txt)
 
@@ -407,7 +407,7 @@ jobs:
         uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2
         with:
           tag_name: v${{ needs.validate-release.outputs.version }}
-          name: Chrome Extension v${{ needs.validate-release.outputs.version }}
+          name: 🚀 My Prompt Manager v${{ needs.validate-release.outputs.version }}
           body_path: release-notes.md
           draft: false
           prerelease: ${{ needs.validate-release.outputs.is-prerelease }}


### PR DESCRIPTION
## 🎯 Overview

Enhances the GitHub release format to use **My Prompt Manager** branding and emoji-enhanced changelog sections for better visual hierarchy and scannability.

## 📊 Changes

### 1. Release Title Format
- **Before:** `Chrome Extension v1.6.0`
- **After:** `🚀 My Prompt Manager v1.6.0`

### 2. Changelog Section Emojis
- ✨ **Added** - New features
- 🔄 **Changed** - Improvements and refactoring
- 🐛 **Fixed** - Bug fixes
- 🔒 **Security** - Security updates
- ⚠️ **Breaking Changes** - Breaking changes

## 📁 Files Modified

- `.github/workflows/release.yml`
  - Line 410: Release title uses branded format
  - Line 315: Adds sed transformations to inject emojis
  - Line 343: Release notes body uses branded title

- `.claude/skills/release-automation/skill.md`
  - Lines 308, 328, 338, 348: Emoji sections

## 🎨 Example Output

When a release is created, users will see:

**Title:**
```
🚀 My Prompt Manager v1.7.0
```

**Body:**
```markdown
# 🚀 My Prompt Manager v1.7.0

## [1.7.0] - 2025-10-21

### ✨ Added
- add release automation skill with changelog generation (#123)
- Icon-Based Compact Filter/Sort Controls for Mobile-First UI (#114)

### 🐛 Fixed
- adjust padding in LibraryView components (#102)
```

## ✅ Benefits

- 🎯 **Brand Recognition**: Project name in every release
- 📊 **Better Scannability**: Emojis make sections instantly recognizable
- 🎨 **Professional Look**: Modern, polished appearance
- 🔄 **Consistent Format**: All future releases use the same style
- 📦 **Automated**: No manual emoji insertion needed

## 🚀 Next Steps After Merge

1. Merge this PR to `main`
2. Run historical backfill script to create releases for v1.0.1 through v1.6.0
3. All historical releases will automatically use the new format
4. Future releases will use the new format going forward

## 🧪 Testing

- ✅ Tested changelog generation with emojis
- ✅ Verified workflow syntax
- ✅ Confirmed release automation skill updates
- ✅ Ready for historical backfill

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)